### PR TITLE
Enable GitHub actions cmp tests

### DIFF
--- a/.github/classroom/autograding.json
+++ b/.github/classroom/autograding.json
@@ -1,0 +1,24 @@
+{
+  "tests": [
+    {
+      "name": "just_simple_test",
+      "setup": "",
+      "run": "cmake . && make just_simple_test",
+      "input": "",
+      "output": "",
+      "comparison": "included",
+      "timeout": 1,
+      "points": null
+    },
+    {
+      "name": "test_using_simple_test",
+      "setup": "",
+      "run": "cmake . && make test_using_simple_test",
+      "input": "",
+      "output": "",
+      "comparison": "included",
+      "timeout": 1,
+      "points": null
+    }
+  ]
+}

--- a/.github/classroom/autograding.json
+++ b/.github/classroom/autograding.json
@@ -3,7 +3,7 @@
     {
       "name": "just_simple_test",
       "setup": "",
-      "run": "cmake . && make just_simple_test",
+      "run": "CI=1 cmake . && make just_simple_test",
       "input": "",
       "output": "",
       "comparison": "included",
@@ -13,7 +13,7 @@
     {
       "name": "test_using_simple_test",
       "setup": "",
-      "run": "cmake . && make test_using_simple_test",
+      "run": "CI=1 cmake . && make test_using_simple_test",
       "input": "",
       "output": "",
       "comparison": "included",

--- a/.github/workflows/classroom.yml
+++ b/.github/workflows/classroom.yml
@@ -1,0 +1,16 @@
+name: GitHub Classroom Workflow
+
+on: [push]
+
+permissions:
+  checks: write
+  actions: read
+  contents: read
+
+jobs:
+  build:
+    name: Autograding
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: education/autograding@v1

--- a/.github/workflows/classroom.yml
+++ b/.github/workflows/classroom.yml
@@ -17,3 +17,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: education/autograding@v1
+  manual-run:
+    name: Run comp tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: cmake . && make all

--- a/.github/workflows/classroom.yml
+++ b/.github/workflows/classroom.yml
@@ -7,18 +7,15 @@ permissions:
   actions: read
   contents: read
 
-env:
-  CI: true
-
 jobs:
   build:
-    name: Autograding
+    name: Test in autograding env
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: education/autograding@v1
   manual-run:
-    name: Run comp tests
+    name: Test in step env
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/classroom.yml
+++ b/.github/workflows/classroom.yml
@@ -7,6 +7,9 @@ permissions:
   actions: read
   contents: read
 
+env:
+  CI: true
+
 jobs:
   build:
     name: Autograding

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,9 @@ else()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror -Wextra-semi -O1 -g -fsanitize=address -fno-omit-frame-pointer")
 endif()
 
-if(NOT DEFINED ENV{CI}) 
+if(DEFINED ENV{CI})
+    message("Skipping gtest part")
+else()
     find_package(GTest REQUIRED)
     include(GoogleTest)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,13 +10,14 @@ else()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror -Wextra-semi -O1 -g -fsanitize=address -fno-omit-frame-pointer")
 endif()
 
+if(NOT DEFINED ENVCI) 
+    find_package(GTest REQUIRED)
+    include(GoogleTest)
 
-find_package(GTest REQUIRED)
-include(GoogleTest)
+    add_executable(test_using_gtest test_using_gtest.cpp gtest_compatible_test.h)
+    target_link_libraries(test_using_gtest GTest::gtest GTest::gtest_main)
+endif()
 
 add_executable(just_simple_test just_simple_test.cpp simple_test.h)
 
 add_executable(test_using_simple_test test_using_simple_test.cpp gtest_compatible_test.h simple_test.h)
-
-add_executable(test_using_gtest test_using_gtest.cpp gtest_compatible_test.h)
-target_link_libraries(test_using_gtest GTest::gtest GTest::gtest_main)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ else()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror -Wextra-semi -O1 -g -fsanitize=address -fno-omit-frame-pointer")
 endif()
 
-if(NOT DEFINED ENVCI) 
+if(NOT DEFINED ENV{CI}) 
     find_package(GTest REQUIRED)
     include(GoogleTest)
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Original repository: https://github.com/nickolaym/simple_test
 ## Macros
 
 ### TEST
-```
+
+```c++
 TEST(suite, name, [enabled]) {
   test body goes here;
 }
@@ -24,7 +25,8 @@ TEST(suite, name, [enabled]) {
 - `enabled` is optional bool expression (runtime constant, evaluated before main())
 
 introduces auxillary object test_name and function
-```
+
+```c++
 void func_name() {
   test body goes here;
 }
@@ -36,7 +38,8 @@ Please don't catch(...) inside it without special need.
 GTest compatibility: if suite or name starts with `DISABLED`, the test will skip.
 
 ### ASSERT_..., EXPECT_...
-```
+
+```c++
 ASSERT_CMP(a, op, b)
 EXPECT_CMP(a, op, b)
 ASSERT_EQ, ASSERT_LT, ASSERT_LE, ... as in GTest
@@ -72,7 +75,7 @@ So, they should be printable.
 
 To print extra messages if an assetion fails, use following syntax:
 
-```
+```c++
 ASSERT_BLABLABLA() << common << C++ << stream << args;
 
 ASSERTION_FAULT(common, C++, stream, args);
@@ -82,7 +85,7 @@ Note that if the assertion passes, nothing will evaluate.
 
 ### Show green assertions
 
-```
+```c++
 SHOW_GREEN_ASSERTIONS(flag)
 ```
 where `flag` is boolean
@@ -98,7 +101,8 @@ See examples in just_simple_test.cpp
 Just implementation of `int main()`
 
 Feel free to call a subsequent function from your `main()` with your fixtures:
-```
+
+```c++
 int main(int argc, char** argv) {
   ...
   int result = simple_test::testing_main(argc, argv);
@@ -109,7 +113,7 @@ int main(int argc, char** argv) {
 
 #### Arguments
 
-```
+```c++
 your_test_application [-h] [--help] [-l] [--list] {patterns}
 ```
 

--- a/just_simple_test.cpp
+++ b/just_simple_test.cpp
@@ -9,8 +9,8 @@ TEST(should_fail, vector_capacity) {
   std::vector<int> xs;
   xs.reserve(100500);
   xs.clear();
-  EXPECT_CMP(xs.capacity(), ==, 0) << " ahaha ? ahaha!";
-  ASSERT_CMP(xs.size(), ==, 1) << " ahaha ? ahaha!";
+  EXPECT_CMP(xs.capacity(), ==, 0ul) << " ahaha ? ahaha!";
+  ASSERT_CMP(xs.size(), ==, 1ul) << " ahaha ? ahaha!";
 }
 
 TEST(should_fail, lots_of_failed_expectations) {


### PR DESCRIPTION
Добавляю прогон тестов в окружении CI, который используется в домашках и дорешках

Сейчас в них производится *только* компиляция, без запуска. Надо дочинить и включить запуск и понапихать какие-то более адекватные проверки